### PR TITLE
Removed over hang from merge conflict

### DIFF
--- a/files/setup.sh
+++ b/files/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 # cd /tmp
 sudo apt-get -y update > /dev/null 2>&1
-<<<<<<< HEAD
+
 sudo apt install -y unzip jq cowsay mysql-client > /dev/null 2>&1
 wget https://releases.hashicorp.com/vault/1.0.3/vault_1.0.3_linux_amd64.zip
 sudo unzip vault_1.0.3_linux_amd64.zip -d /usr/local/bin/


### PR DESCRIPTION
Removed the left over text from a merge conflict which was causing the remote-exec to fail